### PR TITLE
fix: replace pagination_token by next_token

### DIFF
--- a/twitter4j-v2-support/src/main/kotlin/twitter4j/SearchEx.kt
+++ b/twitter4j-v2-support/src/main/kotlin/twitter4j/SearchEx.kt
@@ -115,7 +115,7 @@ private fun TwitterImpl.searchTweetsIn(
     V2Util.addHttpParamIfNotNull(params, "expansions", expansions)
     V2Util.addHttpParamIfNotNull(params, "max_results", maxResults)
     V2Util.addHttpParamIfNotNull(params, "media.fields", mediaFields)
-    V2Util.addHttpParamIfNotNull(params, "pagination_token", nextToken)
+    V2Util.addHttpParamIfNotNull(params, "next_token", nextToken)
     V2Util.addHttpParamIfNotNull(params, "place.fields", placeFields)
     V2Util.addHttpParamIfNotNull(params, "poll.fields", pollFields)
     V2Util.addHttpParamIfNotNull(params, "since_id", sinceId)


### PR DESCRIPTION
This params is now named 'next_token'

See https://developer.twitter.com/en/docs/twitter-api/tweets/search/api-reference/get-tweets-search-recent