### PR TITLE
added likeCount field to User2 PublicMetrics

### DIFF
--- a/twitter4j-v2-support/src/main/kotlin/twitter4j/User2.kt
+++ b/twitter4j-v2-support/src/main/kotlin/twitter4j/User2.kt
@@ -22,14 +22,16 @@ data class User2(
         val followersCount: Int,
         val followingCount: Int,
         val tweetCount: Int,
-        val listedCount: Int
+        val listedCount: Int,
+        val likeCount: Int
     ) {
 
         constructor(json: JSONObject) : this(
             followersCount = ParseUtil.getInt("followers_count", json),
             followingCount = ParseUtil.getInt("following_count", json),
             tweetCount = ParseUtil.getInt("tweet_count", json),
-            listedCount = ParseUtil.getInt("listed_count", json)
+            listedCount = ParseUtil.getInt("listed_count", json),
+            likeCount = ParseUtil.getInt("like_count", json)
         )
 
     }


### PR DESCRIPTION
It seems that Twitter has added a new like_count field within the public_metrics section referring to a user, here is the raw response from the Twitter API:

`{
    "data": [
        {
            "description": "",
            "protected": false,
            "username": "elonmusk",
            "created_at": "2009-06-02T20:12:29.000Z",
            "location": "\uD835\uDD4FÐ",
            "name": "Elon Musk",
            "most_recent_tweet_id": "1740042153965793489",
            "public_metrics": {
                "followers_count": 167413232,
                "following_count": 509,
                "tweet_count": 35342,
                "listed_count": 149558,
                "like_count": 38558
            },
            "verified": true,
            "id": "44196397",
            "verified_type": "blue",
            "profile_image_url": "https://pbs.twimg.com/profile_images/1683325380441128960/yRsRRjGO_normal.jpg"
        } ] }`