### PR TITLE
Update media upload endpoints

### DIFF
--- a/twitter4j-v2-support/src/main/kotlin/twitter4j/TwitterV2Impl.kt
+++ b/twitter4j-v2-support/src/main/kotlin/twitter4j/TwitterV2Impl.kt
@@ -1394,14 +1394,12 @@ class TwitterV2Impl(private val twitter: Twitter) : TwitterV2 {
 
     @Throws(TwitterException::class)
     override fun uploadMediaChunkedInit(size: Long, mediaType: String): LongResponse {
-        val params = arrayListOf(
-            HttpParameter("command", "INIT"),
-            HttpParameter("media_type", mediaType),
-            HttpParameter("total_bytes", size.toString()),
-        )
+        val json = JSONObject()
+        json.put("media_type", mediaType)
+        json.put("total_bytes", size)
 
         return V2ResponseFactory().createLongResponse(
-            post(conf.v2Configuration.baseURL + "media/upload", params.toTypedArray()),
+            post(conf.v2Configuration.baseURL + "media/upload/initialize", json),
             conf,
             "id"
         )
@@ -1410,24 +1408,17 @@ class TwitterV2Impl(private val twitter: Twitter) : TwitterV2 {
     @Throws(TwitterException::class)
     override fun uploadMediaChunkedAppend(mediaId: Long, segmentIndex: Long, fileName: String, media: InputStream) {
         val params = arrayListOf(
-            HttpParameter("command", "APPEND"),
-            HttpParameter("media_id", mediaId.toString()),
-            HttpParameter("segment_index", segmentIndex),
             HttpParameter("media", fileName, media),
+            HttpParameter("segment_index", segmentIndex),
         )
 
-        post(conf.v2Configuration.baseURL + "media/upload", params.toTypedArray())
+        post(conf.v2Configuration.baseURL + "media/upload/${mediaId}/append", params.toTypedArray())
     }
 
     @Throws(TwitterException::class)
     override fun uploadMediaChunkedFinalize(mediaId: Long): LongResponse {
-        val params = arrayListOf(
-            HttpParameter("command", "FINALIZE"),
-            HttpParameter("media_id", mediaId.toString())
-        )
-
         return V2ResponseFactory().createLongResponse(
-            post(conf.v2Configuration.baseURL + "media/upload", params.toTypedArray()),
+            post(conf.v2Configuration.baseURL + "media/upload/${mediaId}/finalize", emptyArray<HttpParameter>()),
             conf,
             "id"
         )


### PR DESCRIPTION
X has changed the v2 API media upload endpoints, see https://devcommunity.x.com/t/media-upload-endpoints-update-and-extended-migration-deadline/241818 and https://docs.x.com/x-api/media/media-upload-initialize
This PR implements those new endpoints.

It would be nice if a new version of this library could be deployed to maven central.